### PR TITLE
docs: align PACT description with 'Signal for multi-agent consensus' tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 
 # PACT — Protocol for Agent Contexture and Trust
 
-**The shared resource and the context that gives it meaning travel together — so agents negotiate with trust.**
+**🤝 Think Signal, but for multi-agent and human consensus. Collapses gate reviews from weeks to days.**
 
-*The open protocol for multi-agent collaboration over a shared resource — documents, transactions, knowledge, and beyond.*
+*The open, MIT-licensed protocol where the shared resource and the context that gives it meaning travel together — so agents negotiate with trust. Documents, transactions, knowledge, deal rooms, and beyond.*
 
 > <sub>The acronym **PACT** is unchanged; all identifiers stay `pact*` (`@pact-protocol/*`, `pact-spec.dev`, the `v2.0.x` tags). The expansion was refined to *Contexture and Trust* — "Trust" matches what the protocol actually delivers (§17 trust model, fail-closed conformance) better than "Truth," and "Contexture" names the core unlock: a fabric and its context move as one. This expansion is **normative from v2.1**; shipped **v2.0.x remains "Protocol for Agent Consensus and Truth"** as-released, frozen for citation stability.</sub>
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pact-protocol/cli",
   "version": "2.0.3",
-  "description": "CLI for the PACT protocol — multi-agent consensus on documents, transactions, knowledge, and beyond",
+  "description": "CLI for PACT — like Signal, but for multi-agent and human consensus. Collapses gate reviews from weeks to days. MIT-licensed protocol for multi-agent collaboration over documents, transactions, knowledge, deal rooms, and beyond.",
   "license": "MIT",
   "bin": {
     "pact": "./bin/pact.js",

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -24,7 +24,7 @@ const program = new Command();
 
 program
   .name('pact')
-  .description('PACT v2.0 — Protocol for Agent Consensus and Truth. Coordination and consensus primitives for multi-agent collaboration on any resource type.')
+  .description('PACT — Like Signal, but for multi-agent and human consensus. Collapses gate reviews from weeks to days. Open, MIT-licensed protocol for multi-agent collaboration on any resource type (documents, transactions, knowledge, deal rooms, and beyond).')
   .version('2.0.3')
   .option('--agent <key>', 'Override the API key for this invocation (simulate a specific agent)')
   .hook('preAction', (thisCommand) => {

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pact-protocol/mcp",
   "version": "2.0.3",
-  "description": "MCP server for the PACT protocol — multi-agent consensus on documents, transactions, knowledge, and beyond",
+  "description": "MCP server for PACT — like Signal, but for multi-agent and human consensus. Collapses gate reviews from weeks to days. MIT-licensed protocol for multi-agent collaboration over documents, transactions, knowledge, deal rooms, and beyond.",
   "license": "MIT",
   "bin": { "pact-mcp": "./bin/pact-mcp.js" },
   "publishConfig": {

--- a/reference-server/package.json
+++ b/reference-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pact-protocol/reference-server",
   "version": "2.0.3",
-  "description": "Minimal in-memory reference server for the PACT protocol — a second independent implementation that makes the v2.0 conformance suite's server-bound vectors executable",
+  "description": "Minimal in-memory reference server for PACT — like Signal, but for multi-agent and human consensus. A second independent implementation that makes the conformance suite's server-bound vectors executable.",
   "license": "MIT",
   "private": true,
   "bin": { "pact-reference-server": "./dist/server.js" },

--- a/site/index.html
+++ b/site/index.html
@@ -4,9 +4,9 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>PACT — Protocol for Agent Contexture and Trust</title>
-<meta name="description" content="PACT is an open, vendor-neutral protocol for multi-agent collaboration over a shared resource. The shared resource and the context that gives it meaning travel together — so agents negotiate with trust.">
-<meta property="og:title" content="PACT — Protocol for Agent Contexture and Trust">
-<meta property="og:description" content="An open, vendor-neutral protocol for multi-agent collaboration over a shared resource.">
+<meta name="description" content="PACT — like Signal, but for multi-agent and human consensus. Collapses gate reviews from weeks to days. Open, MIT-licensed, vendor-neutral protocol where the shared resource and the context that gives it meaning travel together — so agents negotiate with trust.">
+<meta property="og:title" content="PACT — Like Signal, for multi-agent and human consensus">
+<meta property="og:description" content="Open, MIT-licensed protocol for multi-agent and human consensus over a shared resource. Collapses gate reviews from weeks to days.">
 <meta property="og:type" content="website">
 <style>
   :root{
@@ -66,13 +66,15 @@
 <header>
   <div class="wrap">
     <h1><span class="pact">PACT</span> — Protocol for Agent Contexture and Trust</h1>
-    <p class="tagline">The shared resource and the context that gives it meaning travel together — so agents negotiate with trust.</p>
-    <p class="lede">PACT is an open, vendor-neutral protocol for multi-agent
-      collaboration over a shared resource — documents, transactions,
-      knowledge claims, records, and beyond. It defines how independent
-      agents declare positions, surface conflicts, reach consensus, and
-      bind human authorization — without any agent having to trust another
-      agent's word for it.</p>
+    <p class="tagline">🤝 Think Signal, but for multi-agent and human consensus. Collapses gate reviews from weeks to days.</p>
+    <p class="lede">PACT is an open, MIT-licensed, vendor-neutral protocol for
+      multi-agent and human consensus over a shared resource — documents,
+      transactions, knowledge claims, records, deal rooms, and beyond. It
+      defines how independent agents declare positions, surface conflicts,
+      reach consensus, and bind human authorization — without any agent
+      having to trust another agent's word for it. The shared resource and
+      the context that gives it meaning travel together — so agents
+      negotiate with trust.</p>
     <div class="badges">
       <span class="badge">stable <b>v2.0.3</b></span>
       <span class="badge">spec license <b>RF copyright + patent</b></span>


### PR DESCRIPTION
## Summary

Updates the public-facing PACT description across 5 surfaces to lead with the new tagline:

> 🤝 **Think Signal, but for multi-agent and human consensus. Collapses gate reviews from weeks to days.**

Per maintainer direction 2026-05-27. The technical name + backronym + frozen-version blurb stay intact; the Signal analogy is layered *above* the existing positioning, not a replacement.

## Surfaces touched

| Surface | Change |
|---|---|
| [`README.md`](https://github.com/TailorAU/pact/blob/claude/pact-tagline-align/README.md) | Bold tagline + italic sub. Adds "MIT-licensed" + "deal rooms" to the resource list. |
| [`site/index.html`](https://github.com/TailorAU/pact/blob/claude/pact-tagline-align/site/index.html) | `<meta name="description">`, `og:title`, `og:description`, visible `<p class="tagline">` + `<p class="lede">` |
| [`cli/package.json`](https://github.com/TailorAU/pact/blob/claude/pact-tagline-align/cli/package.json) | npm description |
| [`mcp/package.json`](https://github.com/TailorAU/pact/blob/claude/pact-tagline-align/mcp/package.json) | npm description |
| [`reference-server/package.json`](https://github.com/TailorAU/pact/blob/claude/pact-tagline-align/reference-server/package.json) | npm description (stays private) |
| [`cli/src/index.ts`](https://github.com/TailorAU/pact/blob/claude/pact-tagline-align/cli/src/index.ts) | Runtime `pact --help` description — also drops stale "v2.0 — Protocol for Agent Consensus and Truth" pin since the CLI no longer ties to a single spec version |

## Deliberately NOT touched

- The backronym itself (stays "Contexture and Trust" per v2.1 scope decision; v2.0.x stays "Consensus and Truth" as-shipped — both frozen for citation stability)
- The §-frozen spec text (AGENTS.md rule 4 — `spec/v0.3`, `v0.4`, `v1.0`, `v1.1`, `v2.0` all untouched)
- AGENTS.md (agent-onboarding context, not marketing copy)
- GOVERNANCE.md / CONTRIBUTING.md (charter docs)

## Why this works without breaking the backronym

The Signal analogy is a *layperson-facing tagline* — what PACT does in one sentence. The backronym ("Protocol for Agent Contexture and Trust") is the *technical name*. Both can live together, like Signal's own product framing (the app is "Signal Private Messenger" but the tagline is "Speak Freely").

"Consensus" in the new tagline also bridges nicely to the v2.0.x as-shipped backronym ("Consensus and Truth"); "Trust" remains the v2.1+ refinement underneath.

## Test plan

- [x] `cd cli && npm run build` — clean (verified locally)
- [x] No spec text touched (AGENTS.md rule 4 honoured)
- [ ] CI green (will fire automatically; touches `cli/`, `mcp/`, `reference-server/`, and `site/` paths)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)